### PR TITLE
undefined symbol: NxClient_GetDefaultJoinSettings 

### DIFF
--- a/ScreenCapture/CMakeLists.txt
+++ b/ScreenCapture/CMakeLists.txt
@@ -54,7 +54,11 @@ endif()
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
+if (BUILD_BROADCOM)
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl -lnxclient)
+else ()
 target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl)
+endif()
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)


### PR DESCRIPTION
libnxclient was not linked, below changes are needed for this "undefined symbol" failure.

Error:
/usr/bin/WPEFramework: symbol lookup error: 
/usr/lib/wpeframework/plugins/libWPEFrameworkScreenCapture.so: undefined symbol: NxClient_GetDefaultJoinSettings 